### PR TITLE
Support PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^7.4 || ^8.0",
         "illuminate/support": "^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^7.4 || ^8.0",
+        "php": ">=7.3",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^7.3 || ^7.4 || ^8.0",
-        "illuminate/support": "^6.0"
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0",


### PR DESCRIPTION
This PR adds PHP8 & Laravel 7/8 support. As of right now, it can't be installed on Laravel 8 because of the illuminate/support package giving conflicts.